### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   cypress-run:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/adrianjiga/CypressAutomationExample/security/code-scanning/1](https://github.com/adrianjiga/CypressAutomationExample/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow only needs to read repository contents (e.g., for checking out code and running tests), the permissions should be limited to `contents: read`. This block can be added at the root level of the workflow to apply to all jobs, or specifically to the `cypress-run` job.

The best approach is to add the `permissions` block at the root level of the workflow, as this ensures all jobs inherit the least privilege by default unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
