### PR TITLE
Fix missing ESLint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "eslint": "^9.31.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-cypress": "^5.1.0",
+    "@eslint/js": "^9.31.0",
     "globals": "^16.3.0",
     "mochawesome": "^7.1.3",
     "mochawesome-merge": "^5.0.0",


### PR DESCRIPTION
## Summary
- add `@eslint/js` to dev dependencies for linting

## Testing
- `npm run lint` *(fails: Cannot find package)*

------
https://chatgpt.com/codex/tasks/task_e_6881e0303e3c832cbb395ffaaf0171ac