### PR TITLE
docs: truth-up README against the actual codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,13 @@ npm install
 │   │   ├── waitUntilExample.cy.js    # Custom wait patterns
 │   │   └── webTables.cy.js           # Table CRUD operations
 │   ├── fixtures/                     # Test data files
-│   │   ├── book.json
-│   │   └── post.json
+│   │   ├── book.json                 # Upload payload for the register form
+│   │   ├── post.json                 # Expected body for the get-by-id API test
+│   │   └── schemas/                  # Ajv JSON Schemas (draft-07), keyed by $id
+│   │       ├── comment-schema.json
+│   │       ├── comments-array-schema.json
+│   │       ├── post-schema.json
+│   │       └── posts-array-schema.json
 │   ├── pages/                        # Page Object Models
 │   │   ├── ButtonsPage.js
 │   │   ├── RegisterFormPage.js
@@ -63,6 +68,9 @@ npm install
 ├── eslint.config.js                  # ESLint configuration
 ├── jsconfig.json                     # JavaScript/IDE configuration
 ├── tsconfig.json                     # TypeScript configuration
+├── .nvmrc                            # Node version pin (22), matches CI
+├── .prettierrc
+├── LICENSE
 └── package.json
 ```
 
@@ -134,6 +142,19 @@ npm run docker:clean
 |-----------|----------|
 | `api.cy.js` | JSONPlaceholder API - list posts, fetch by ID, filter comments, error handling, create, delete |
 
+Responses are validated against JSON Schema (draft-07) with Ajv. Every schema in
+`cypress/fixtures/schemas/` carries an `$id`, and all of them are registered against a single
+Ajv instance in `commands.js`. That is what lets an array schema `$ref` its item schema
+(`posts-array` → `post`) instead of duplicating the item shape, and lets specs validate by
+name rather than by import:
+
+```javascript
+cy.validateSchema(response.body, "posts-array");
+```
+
+Ajv runs with `allErrors: true`, so a failing assertion reports every violation with its
+JSON path — not just the first one it hits.
+
 ### Web Tables Tests (`@webTables`)
 
 | Test File | Coverage |
@@ -174,31 +195,40 @@ import { userFactory } from "../support/factories";
 const user = userFactory.generate();
 // { firstName, lastName, email, age, salary, department }
 
+const engineer = userFactory.generate({ department: "Engineering" });
+// Same shape, with the given fields overridden
+
 const formUser = userFactory.generateFormUser();
 // { firstName, lastName, email, mobile, address }
 
-const users = userFactory.generateBatch(5);
-// Array of 5 user objects
+const age = userFactory.generateAge();
+// Random integer in [18, 65]
 ```
 
 ## Custom Commands
 
-### Form Handling
-- `cy.fillForm(formData)` - Fill multiple fields by ID
-- `cy.submitFormAndVerify(formData, buttonId, modalTitle)` - Submit and verify
+Defined in `cypress/support/commands.js`, typed in `cypress/support/index.d.ts`.
 
 ### UI Interactions
 - `cy.waitAndClick(selector, options)` - Wait for visibility then click
 - `cy.selectDate(input, month, year, day)` - Date picker selection
-- `cy.selectDropdownOption(dropdown, index)` - Custom dropdown selection
 
 ### Assertions
 - `cy.verifyCssProperty(selector, property, value)` - CSS validation
-- `cy.verifyValidationError(selector)` - Form error styling
+- `cy.verifyValidationError(selector, errorColor?)` - Form error styling
 
 ### API Helpers
-- `cy.apiRequest(method, url, options)` - Request with default headers
-- `cy.validateSchema(data, schema)` - Response schema validation
+- `cy.apiRequest(method, url, options)` - Request with default headers, `failOnStatusCode: false`
+- `cy.validateSchema(data, schema)` - Ajv draft-07 validation, reporting every violation at once
+
+### Utilities
+- `cy.logMessage(message, data?)` - Log to both the Cypress runner and the console
+- `cy.takeScreenshot(name, options?)` - Timestamped screenshot
+
+Form-filling is **not** a custom command. Each page object owns its own form logic
+(`RegisterFormPage.fillCompleteForm()`, `WebTablesPage.fillForm()`) because the two forms
+have different field sets and different validation semantics — a shared `fillForm` command
+collapsed into a lowest-common-denominator helper that neither page could use cleanly.
 
 ## Configuration
 
@@ -239,16 +269,25 @@ Runs on every PR to master:
 
 - **Schedule**: Monday-Friday at 07:00 UTC
 - **Triggers**: Push to master, manual dispatch
-- **Matrix**: 
-  - Groups: API, UI, WebTables
-  - Browsers: Chrome, Firefox
-  - Viewports: Desktop, Mobile, Tablet
+
+Three jobs:
+
+| Job | Shape |
+|-----|-------|
+| `test` | Groups (`@api`, `@ui`, `@webTables`) × Browsers (Chrome, Firefox) at the desktop viewport. `@api` is skipped on Firefox — the suite makes no browser-specific assertions, so a second engine buys nothing. |
+| `responsive-tests` | `@ui` only, on Chrome, at the mobile and tablet viewports. Separate from the main matrix so viewport coverage doesn't multiply against the browser axis. |
+| `merge-reports` | Runs after both (`if: always()`), downloads every shard's artifacts and merges the mochawesome JSON into a single HTML report. |
+
+All `actions/*` references are pinned to full commit SHAs with a trailing `# vX.Y.Z` comment.
+SHAs are immutable, so a compromised tag cannot silently re-point at different code.
+Dependabot recognises the pattern and bumps the SHA and the comment together.
 
 ### Artifacts
 
 Test artifacts are retained for 30 days:
 - Screenshots (on failure)
-- Videos (on failure only)
+- Videos — recorded for every spec, then deleted for passing specs by the `after:spec`
+  hook in `cypress.config.js`, so only failures survive
 - Mochawesome reports
 
 ## Reports
@@ -305,6 +344,13 @@ Dependabot monitors and updates:
 - npm packages (weekly, Mondays)
 - Docker images (weekly, Mondays)
 - GitHub Actions (weekly, Mondays)
+
+Updates are grouped per ecosystem, so a week's bumps arrive as one PR rather than six.
+
+**Held-back versions** are recorded in `.github/dependabot.yml` with the reason inline.
+Currently: `cypress@15.19.0`, which ships `@babel/preset-typescript` without a
+`package.json`, so the bundled preprocessor cannot resolve it and every spec dies at 0ms
+(see PR #162). Remove the entry once a fixed release is out.
 
 ## Cleanup
 

--- a/README.md
+++ b/README.md
@@ -334,9 +334,27 @@ npm run typecheck     # Run TypeScript checks
 ## Docker Configuration
 
 Each test container runs with:
-- Base image: `cypress/included:15.14.2`
+- Base image: `cypress/included:15.18.1`
 - Memory limit: 2GB
 - Memory reservation: 1GB
+
+### The image tag and the npm dependency are one pin, not two
+
+`cypress/included:X` ships a pre-downloaded Cypress binary for X in the image's binary
+cache. The Dockerfile then runs `npm ci`, which installs whatever `package-lock.json`
+resolves. **These must be the same version.** If they diverge, the npm package looks for a
+binary that isn't in the cache and the container dies before a single spec runs.
+
+Dependabot watches both, on the same weekly schedule, but raises them as separate PRs —
+merge them together. Any version held back in the npm `ignore` list must be held back in
+the docker one too; `.github/dependabot.yml` keeps the two entries adjacent and cross-
+referenced for that reason.
+
+The six-line Dockerfile is deliberate. `docker-compose.yml` bind-mounts the working tree
+over `/app` and declares a per-service `command:`, so under compose the `COPY . .` and
+`CMD` are redundant — they exist so that a plain `docker build` + `docker run` also works.
+The anonymous `/app/node_modules` volume is what stops the bind mount from shadowing the
+container's installed dependencies.
 
 ## Dependency Management
 


### PR DESCRIPTION
The README documented commands and helpers that were deleted months ago, and described the CI pipeline in a shape it never had. Everything here is a correction to match what the code actually does — no behaviour changes.

## Corrections

- **Custom Commands** — removed `cy.fillForm`, `cy.submitFormAndVerify` and `cy.selectDropdownOption`. All three were deleted in dc2936b ("drop legacy id-based form helpers") but stayed documented. Added the four commands that were never listed: `cy.logMessage`, `cy.takeScreenshot`, and the real signatures for `cy.apiRequest` / `cy.validateSchema`.
- **Test Data Factories** — removed `userFactory.generateBatch(5)`, deleted in 6109da4. Added `generateAge()` and the overrides argument, both of which specs actually use.
- **CI/CD** — the old text described a single matrix over groups × browsers × viewports. It's really three jobs: `test` (groups × browsers at desktop), `responsive-tests` (`@ui` only, mobile + tablet, kept off the browser axis on purpose), and `merge-reports`.
- **Project structure** — added the `fixtures/schemas/` tree, `.nvmrc`, `.prettierrc` and `LICENSE`.
- **Docker base image** — `15.14.2` → `15.18.1`.

## Additions

- Documented why the Ajv schemas are registered by `$id` against one shared instance: it's what lets `posts-array` `$ref` `post` instead of duplicating the item shape, and what makes `cy.validateSchema(body, "posts-array")` work by name.
- Documented that videos are recorded for every spec and then deleted for passing ones by the `after:spec` hook — "on failure only" was the effect, not the mechanism.
- Documented the held-back `cypress@15.19.0` and the reason, so the next person doesn't try to un-pin it.
- Recorded *why* there is no shared `fillForm` command, so it doesn't get re-added.

## Verification

`npm run lint` and `npm run format:check` both pass. Markdown only — no JS touched.