### PR TITLE
fix(docker): move the cypress image tag and npm dep together to 15.20.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,13 @@ updates:
       docker-dependencies:
         patterns:
           - "*"
+    ignore:
+      # Mirror of the npm ignore above. The Dockerfile tag and the npm dependency
+      # are two pins of the same Cypress version and must stay equal, so a version
+      # blocked for npm has to be blocked here too — otherwise the docker ecosystem
+      # bumps the image past a version npm is still held back from.
+      - dependency-name: "cypress/included"
+        versions: ["15.19.0"]
     commit-message:
       prefix: "docker"
       include: "scope"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 #
 # Dependabot bumps this tag and the npm dependency on the same weekly schedule, but
 # they arrive as separate PRs — merge them together, never one alone.
-FROM cypress/included:15.18.1
+FROM cypress/included:15.20.1
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,20 @@
-FROM cypress/included:15.19.0
+# The tag MUST match the `cypress` version resolved in package-lock.json.
+#
+# `cypress/included:X` ships a pre-downloaded Cypress binary for X in the image's
+# binary cache. The `npm ci` below then installs whatever the lockfile pins. If the
+# two disagree, the npm package looks for a binary that is not in the cache and the
+# container fails before a single spec runs.
+#
+# Dependabot bumps this tag and the npm dependency on the same weekly schedule, but
+# they arrive as separate PRs — merge them together, never one alone.
+FROM cypress/included:15.18.1
 
 WORKDIR /app
 
 COPY package*.json ./
 
 RUN npm ci
+
+COPY . .
+
+CMD ["npx", "cypress", "run"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@cypress/grep": "^6.0.2",
         "@faker-js/faker": "^10.5.0",
-        "cypress": "^15.18.1"
+        "cypress": "^15.20.1"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -1313,9 +1313,9 @@
       }
     },
     "node_modules/arch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-3.0.0.tgz",
+      "integrity": "sha512-AmIAC+Wtm2AU8lGfTtHsw0Y9Qtftx2YXEEtiBP10xFUtMOA+sHHx6OAddyL52mUKh1vsXQ6/w1mVDptZCyUt4Q==",
       "funding": [
         {
           "type": "github",
@@ -1329,7 +1329,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1870,9 +1871,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "15.18.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.18.1.tgz",
-      "integrity": "sha512-JtkTVtUE2lvLYgZCaug+Uai0H9IqsJirlBO49c87QwG0bJUGvAUVBz1EJve0b0oaYP244Ew9M0BkrHpcqkYxmw==",
+      "version": "15.20.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-15.20.1.tgz",
+      "integrity": "sha512-7GV3O7vQQG+EVVv9BGs6lCHY49x25jVi/z1+zdjuuq/o3eZeDwmGPJpRYnOWeGvQxTCtkydXWHBPhV8xuGXPLg==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -1881,7 +1882,7 @@
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
         "@types/tmp": "^0.2.3",
-        "arch": "^2.2.0",
+        "arch": "^3.0.0",
         "blob-util": "^2.0.2",
         "bluebird": "^3.7.2",
         "buffer": "^5.7.1",
@@ -1912,7 +1913,6 @@
         "systeminformation": "^5.31.1",
         "tmp": "~0.2.4",
         "tree-kill": "1.2.2",
-        "tslib": "1.14.1",
         "untildify": "^4.0.0",
         "yauzl": "^3.3.1"
       },
@@ -1928,12 +1928,6 @@
       "resolved": "https://registry.npmjs.org/cypress-wait-until/-/cypress-wait-until-3.0.2.tgz",
       "integrity": "sha512-iemies796dD5CgjG5kV0MnpEmKSH+s7O83ZoJLVzuVbZmm4lheMsZqAVT73hlMx4QlkwhxbyUzhOBUOZwoOe0w==",
       "dev": true
-    },
-    "node_modules/cypress/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/dashdash": {
       "version": "1.14.1",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
   "dependencies": {
     "@cypress/grep": "^6.0.2",
     "@faker-js/faker": "^10.5.0",
-    "cypress": "^15.18.1"
+    "cypress": "^15.20.1"
   },
   "overrides": {
     "diff": ">=8.0.3",


### PR DESCRIPTION
`Dockerfile` was pinned to `cypress/included:15.19.0` — the exact version `.github/dependabot.yml` blocks for npm because it ships `@babel/preset-typescript` without a `package.json`, so every spec dies at 0ms (see #162).

## The actual defect

The image tag and the npm dependency are **two independent pins of the same thing**, and nothing enforced that they agree.

`cypress/included:X` ships a pre-downloaded Cypress binary for X in the image's binary cache. The Dockerfile then runs `npm ci`, which installs whatever `package-lock.json` resolves. If they disagree, the npm package looks for a binary that isn't in the cache and the container fails before any spec runs.

With the image at 15.19.0 and the lockfile at 15.18.1, `npm run test:docker:ui|api|webtables|all` were all broken.

## How it got in

The npm ecosystem had an `ignore` entry for `cypress@15.19.0`. The docker ecosystem had none. Dependabot bumped the image to 15.19.0 in b45798d, *before* the npm block was added in e267a53 — the npm side got fixed and the docker side was never walked back.

## Changes

- **Both pins moved together to 15.20.1**, the current latest, which exists as both an npm release and a `cypress/included` tag. Past the broken 15.19.0.
- The invariant is spelled out in a `Dockerfile` header comment so the next person doesn't move one pin alone.
- **Mirrored the `15.19.0` block into the docker ecosystem** in `dependabot.yml`, cross-referenced to the npm entry. This is the systemic fix — it stops the docker ecosystem from ever again bumping past a version npm is held back from.
- Added `COPY . .` and `CMD` so a plain `docker build` + `docker run` works. Under compose these are redundant (bind mount + per-service `command:`), but their absence meant the image was only usable one way. Also matches the sibling Playwright Dockerfile.

## Supersedes #165

#165 bumped the image to 15.20.0 **alone**, which would have left the lockfile at 15.18.1 — the same mismatch class this PR fixes, just at different numbers. Closing it in favour of this.

#166 still carries a `cypress: ^15.18.1 → ^15.20.0` line among its 6 updates; that line is now redundant and will drop out on rebase. Its other 5 packages are untouched here.

## Verification

Run locally on 15.20.1:

```
npx cypress verify   → Verified Cypress!
npx cypress version  → package 15.20.1 / binary 15.20.1   (aligned)
npm run lint         → pass
npm run format:check → pass
npm run typecheck    → pass
npm run test:smoke   → 4/4 specs passed in 6s
```

The smoke run matters specifically: the 15.19.0 failure mode was specs dying at 0ms, which `cypress verify` alone would not catch. All four specs execute and assert.

The 3 `npm audit` high findings (brace-expansion, fast-uri, js-yaml) are pre-existing on `master` — the lockfile diff here touches only `cypress`, `arch` and `tslib`.