### PR TITLE
docs: stop duplicating the docker image tag in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,7 +334,8 @@ npm run typecheck     # Run TypeScript checks
 ## Docker Configuration
 
 Each test container runs with:
-- Base image: `cypress/included:15.18.1`
+- Base image: `cypress/included` — the tag is declared in the [`Dockerfile`](Dockerfile) and
+  deliberately not repeated here, because a version written in two places drifts
 - Memory limit: 2GB
 - Memory reservation: 1GB
 


### PR DESCRIPTION
Follow-up to #167 and #168 — fixing drift those two introduced between them.

## What happened

#167 documented the Docker base image as `cypress/included:15.18.1`, matching the pin in #168 at the time. #168 was then retargeted to `15.20.1` after Dependabot turned out to have both halves of the upgrade already proposed. The Dockerfile moved; the README line did not.

Result on `master`: README said `15.18.1`, Dockerfile said `15.20.1`. Nothing broken at runtime — the Dockerfile is the only pin that executes — but it is the same documentation-drift class #167 existed to eliminate, reintroduced within the same change set.

## Fix

The version is no longer stated in the README at all. It links to the `Dockerfile`, which is the file that actually determines it.

Re-syncing the number would have restored the duplicated fact and guaranteed a third drift on the next bump. Dependabot edits the `Dockerfile` and has no reason to touch prose, so any version transcribed into the README is drift waiting to happen.

The surrounding section still explains *why* the image tag and the npm dependency must move together — that is a design constraint worth documenting. Only the transcribed number is gone.

## Verification

```
grep -nE "cypress/included:[0-9]" README.md   → no matches
```