### PR TITLE
refactor(pages): address country and city options by name, not position

### DIFF
--- a/cypress/e2e/registerForm.cy.js
+++ b/cypress/e2e/registerForm.cy.js
@@ -23,8 +23,8 @@ describe("Register Form", () => {
         subjects: ["Maths"],
         hobbies: ["sports", "reading"],
         picture: "cypress/fixtures/book.json",
-        state: 0,
-        city: 0,
+        state: "germany",
+        city: "berlin",
       });
 
       RegisterFormPage.submit().verifySubmissionSuccess();

--- a/cypress/pages/RegisterFormPage.js
+++ b/cypress/pages/RegisterFormPage.js
@@ -32,9 +32,9 @@ export const RegisterFormPage = {
     uploadPicture: '[data-cy="upload-picture"]',
     currentAddress: '[data-cy="address-input"]',
     stateDropdown: '[data-cy="state-dropdown"]',
-    stateOption: (index) => `#state-option-${index}`,
+    stateOption: (country) => `[data-cy="state-option-${country}"]`,
     cityDropdown: '[data-cy="city-dropdown"]',
-    cityOption: (index) => `#city-option-${index}`,
+    cityOption: (city) => `[data-cy="city-option-${city}"]`,
     submitButton: '[data-cy="submit-btn"]',
     closeModalButton: '[data-cy="close-modal-btn"]',
     modalTitle: '[data-cy="modal-title"]',
@@ -138,22 +138,32 @@ export const RegisterFormPage = {
   },
 
   /**
-   * Select state from dropdown
-   * @param {number} optionIndex - Index of the state option (0-based)
+   * Select a country from the custom dropdown.
+   *
+   * Addressed by name rather than position: the old `#state-option-N` ids encoded an
+   * ordering the spec had to know but never stated, so `selectState(0)` silently meant
+   * Germany.
+   *
+   * @param {'germany'|'france'|'spain'|'italy'|'netherlands'} country
    */
-  selectState(optionIndex = 0) {
+  selectState(country = "germany") {
     cy.get(this.selectors.stateDropdown).click();
-    cy.get(this.selectors.stateOption(optionIndex)).click();
+    cy.get(this.selectors.stateOption(country)).click();
     return this;
   },
 
   /**
-   * Select city from dropdown
-   * @param {number} optionIndex - Index of the city option (0-based)
+   * Select a city from the custom dropdown. Cities are populated by the chosen country, so
+   * this must run after {@link selectState}.
+   *
+   * Lower-cased and hyphenated, matching how the page builds the attribute, so "Frankfurt"
+   * is `frankfurt`.
+   *
+   * @param {string} city - e.g. "berlin"
    */
-  selectCity(optionIndex = 0) {
+  selectCity(city = "berlin") {
     cy.get(this.selectors.cityDropdown).click();
-    cy.get(this.selectors.cityOption(optionIndex)).click();
+    cy.get(this.selectors.cityOption(city)).click();
     return this;
   },
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,7 +25,7 @@ ajv.addSchema([
  * Wait for an element to be visible and then click it
  * Useful for elements that may take time to appear or need force clicking
  * @example
- * cy.waitAndClick('#submit')
+ * cy.waitAndClick('[data-cy="submit-btn"]')
  * cy.waitAndClick('.modal-button', { force: true, timeout: 15000 })
  * @param {string} selector - Element selector
  * @param {Object} [options={}] - Click options
@@ -46,7 +46,7 @@ Cypress.Commands.add("waitAndClick", (selector, options = {}) => {
 /**
  * Select a date from the custom datepicker component
  * @example
- * cy.selectDate('#dateInput', 'January', '1990', '15')
+ * cy.selectDate('[data-cy="date-of-birth-input"]', 'January', '1990', '15')
  * @param {string} dateInput - Selector for the date input
  * @param {string} month - Month name (e.g., 'January')
  * @param {string} year - Year (e.g., '1990')
@@ -66,7 +66,7 @@ Cypress.Commands.add("selectDate", (dateInput, month, year, day) => {
 /**
  * Verify an element has a specific CSS property value
  * @example
- * cy.verifyCssProperty('#input', 'border-color', 'rgb(220, 53, 69)')
+ * cy.verifyCssProperty('[data-cy="first-name-input"]', 'border-color', 'rgb(220, 53, 69)')
  * @param {string} selector - Element selector
  * @param {string} property - CSS property name
  * @param {string} value - Expected CSS value
@@ -78,7 +78,7 @@ Cypress.Commands.add("verifyCssProperty", (selector, property, value) => {
 /**
  * Verify an input field has validation error styling
  * @example
- * cy.verifyValidationError('#email')
+ * cy.verifyValidationError('[data-cy="email-input"]')
  * @param {string} selector - Input selector
  * @param {string} [errorColor='rgb(220, 53, 69)'] - Expected error border color
  */


### PR DESCRIPTION
The last id-based selectors in this suite. Removing them clears the final blocker on deleting the `#state-option-N` / `#city-option-N` ids from the helper site.

## What changed

`RegisterFormPage` addressed dropdown options positionally:

```js
stateOption: (index) => `#state-option-${index}`,
cityOption:  (index) => `#city-option-${index}`,
```

Both now use the named `data-cy` hooks the page already exposes:

```js
stateOption: (country) => `[data-cy="state-option-${country}"]`,
cityOption:  (city)    => `[data-cy="city-option-${city}"]`,
```

This is an API change, not a selector swap — `selectState("germany")` replaces `selectState(0)`, and `registerForm.cy.js` updated to match.

Worth doing rather than keeping the ids for these two. `selectState(0)` encoded an ordering the spec had to know but never stated, and the spec then asserted `"State and City": "Germany Berlin"` — an expectation with no visible connection to the `0` that produced it. The named form says what it means and survives a reordering of the dropdown.

Mirrors the same change in PlaywrightAutomationExample#39.

## Also

`commands.js` JSDoc examples used id selectors (`cy.waitAndClick('#submit')`, `cy.verifyValidationError('#email')`). They are the first thing anyone reads when adding a command, so they were teaching the pattern this project has moved away from. Now `[data-cy="submit-btn"]`, `[data-cy="email-input"]` and friends — all verified to exist on the helper page.

## Verified

```
npx cypress run  →  18/18 specs passing
```

Lint, format check, and typecheck all clean.

## What this unlocks

With this merged, **no suite references the helper site's raw ids**. I surveyed all three:

- Playwright — migrated in #39
- Selenium — migrated in SeleniumAutomationExample#59
- Cypress — this PR

The only remaining `#` selectors anywhere are `#docsearch-input` on `docs.cypress.io`, which is a third-party site, and one explanatory JSDoc comment.

A follow-up on `adrianjiga.github.io` can now delete the ids that exist *purely* as test hooks — though that turns out to be only 8 of them. The rest are load-bearing: the pages' own JavaScript resolves them via `getElementById`, and several are targets of `<label for="…">` associations that the accessibility work depends on.