### PR TITLE
refactor(pages): use camelCase data-cy hooks

### DIFF
--- a/cypress/e2e/registerForm.cy.js
+++ b/cypress/e2e/registerForm.cy.js
@@ -23,8 +23,8 @@ describe("Register Form", () => {
         subjects: ["Maths"],
         hobbies: ["sports", "reading"],
         picture: "cypress/fixtures/book.json",
-        state: "germany",
-        city: "berlin",
+        state: "Germany",
+        city: "Berlin",
       });
 
       RegisterFormPage.submit().verifySubmissionSuccess();

--- a/cypress/pages/ButtonsPage.js
+++ b/cypress/pages/ButtonsPage.js
@@ -6,12 +6,12 @@ export const ButtonsPage = {
   url: "/qa/helpers/buttons",
 
   selectors: {
-    doubleClickButton: '[data-cy="double-click-btn"]',
-    rightClickButton: '[data-cy="right-click-btn"]',
-    dynamicClickButton: '[data-cy="dynamic-click-btn"]',
-    doubleClickMessage: '[data-cy="double-click-message"]',
-    rightClickMessage: '[data-cy="right-click-message"]',
-    dynamicClickMessage: '[data-cy="dynamic-click-message"]',
+    doubleClickButton: '[data-cy="doubleClickBtn"]',
+    rightClickButton: '[data-cy="rightClickBtn"]',
+    dynamicClickButton: '[data-cy="dynamicClickBtn"]',
+    doubleClickMessage: '[data-cy="doubleClickMessage"]',
+    rightClickMessage: '[data-cy="rightClickMessage"]',
+    dynamicClickMessage: '[data-cy="dynamicClickMessage"]',
   },
 
   messages: {

--- a/cypress/pages/RegisterFormPage.js
+++ b/cypress/pages/RegisterFormPage.js
@@ -6,39 +6,40 @@ export const RegisterFormPage = {
   url: "/qa/helpers/automation-practice-form",
 
   selectors: {
-    firstName: '[data-cy="first-name-input"]',
-    lastName: '[data-cy="last-name-input"]',
-    email: '[data-cy="email-input"]',
-    mobile: '[data-cy="mobile-input"]',
-    genderMale: '[data-cy="gender-male"]',
-    genderFemale: '[data-cy="gender-female"]',
-    genderOther: '[data-cy="gender-other"]',
+    firstName: '[data-cy="firstNameInput"]',
+    lastName: '[data-cy="lastNameInput"]',
+    email: '[data-cy="emailInput"]',
+    mobile: '[data-cy="mobileInput"]',
+    genderMale: '[data-cy="genderMale"]',
+    genderFemale: '[data-cy="genderFemale"]',
+    genderOther: '[data-cy="genderOther"]',
     genderLabel: (id) => {
       const map = {
-        1: '[data-cy="gender-male-label"]',
-        2: '[data-cy="gender-female-label"]',
-        3: '[data-cy="gender-other-label"]',
+        1: '[data-cy="genderMaleLabel"]',
+        2: '[data-cy="genderFemaleLabel"]',
+        3: '[data-cy="genderOtherLabel"]',
       };
       return map[id];
     },
-    dateOfBirthInput: '[data-cy="date-of-birth-input"]',
-    monthSelect: '[data-cy="month-select"]',
-    yearSelect: '[data-cy="year-select"]',
-    daySelector: (day) => `[data-cy="day-${day}"]`,
-    subjectsInput: '[data-cy="subjects-input"]',
-    hobbySports: '[data-cy="hobby-sports"]',
-    hobbyReading: '[data-cy="hobby-reading"]',
-    hobbyMusic: '[data-cy="hobby-music"]',
-    uploadPicture: '[data-cy="upload-picture"]',
-    currentAddress: '[data-cy="address-input"]',
-    stateDropdown: '[data-cy="state-dropdown"]',
-    stateOption: (country) => `[data-cy="state-option-${country}"]`,
-    cityDropdown: '[data-cy="city-dropdown"]',
-    cityOption: (city) => `[data-cy="city-option-${city}"]`,
-    submitButton: '[data-cy="submit-btn"]',
-    closeModalButton: '[data-cy="close-modal-btn"]',
-    modalTitle: '[data-cy="modal-title"]',
-    resultTable: '[data-cy="result-table"] tbody tr',
+    dateOfBirthInput: '[data-cy="dateOfBirthInput"]',
+    monthSelect: '[data-cy="monthSelect"]',
+    yearSelect: '[data-cy="yearSelect"]',
+    daySelector: (day) => `[data-cy="day${day}"]`,
+    subjectsInput: '[data-cy="subjectsInput"]',
+    hobbySports: '[data-cy="hobbySports"]',
+    hobbyReading: '[data-cy="hobbyReading"]',
+    hobbyMusic: '[data-cy="hobbyMusic"]',
+    uploadPicture: '[data-cy="uploadPicture"]',
+    currentAddress: '[data-cy="addressInput"]',
+    stateDropdown: '[data-cy="stateDropdown"]',
+    stateOption: (country) =>
+      `[data-cy="stateOption${country.replace(/\s+/g, "")}"]`,
+    cityDropdown: '[data-cy="cityDropdown"]',
+    cityOption: (city) => `[data-cy="cityOption${city.replace(/\s+/g, "")}"]`,
+    submitButton: '[data-cy="submitBtn"]',
+    closeModalButton: '[data-cy="closeModalBtn"]',
+    modalTitle: '[data-cy="modalTitle"]',
+    resultTable: '[data-cy="resultTable"] tbody tr',
   },
 
   messages: {
@@ -144,9 +145,9 @@ export const RegisterFormPage = {
    * ordering the spec had to know but never stated, so `selectState(0)` silently meant
    * Germany.
    *
-   * @param {'germany'|'france'|'spain'|'italy'|'netherlands'} country
+   * @param {'Germany'|'France'|'Spain'|'Italy'|'Netherlands'} country - the visible name
    */
-  selectState(country = "germany") {
+  selectState(country = "Germany") {
     cy.get(this.selectors.stateDropdown).click();
     cy.get(this.selectors.stateOption(country)).click();
     return this;
@@ -159,9 +160,9 @@ export const RegisterFormPage = {
    * Lower-cased and hyphenated, matching how the page builds the attribute, so "Frankfurt"
    * is `frankfurt`.
    *
-   * @param {string} city - e.g. "berlin"
+   * @param {string} city - the visible name, e.g. "Berlin"
    */
-  selectCity(city = "berlin") {
+  selectCity(city = "Berlin") {
     cy.get(this.selectors.cityDropdown).click();
     cy.get(this.selectors.cityOption(city)).click();
     return this;

--- a/cypress/pages/WebTablesPage.js
+++ b/cypress/pages/WebTablesPage.js
@@ -6,26 +6,26 @@ export const WebTablesPage = {
   url: "/qa/helpers/webtables",
 
   selectors: {
-    searchBox: '[data-cy="search-box"]',
-    addNewRecordButton: '[data-cy="add-record-btn"]',
-    tableBody: '[data-cy="table-body"]',
-    rows: '[data-cy="table-body"] tr',
+    searchBox: '[data-cy="searchBox"]',
+    addNewRecordButton: '[data-cy="addRecordBtn"]',
+    tableBody: '[data-cy="tableBody"]',
+    rows: '[data-cy="tableBody"] tr',
     tableCell: "td",
-    modal: '[data-cy="registration-modal"]',
-    modalTitle: '[data-cy="modal-title"]',
-    firstName: '[data-cy="modal-first-name"]',
-    lastName: '[data-cy="modal-last-name"]',
-    email: '[data-cy="modal-email"]',
-    age: '[data-cy="modal-age"]',
-    salary: '[data-cy="modal-salary"]',
-    department: '[data-cy="modal-department"]',
-    submitButton: '[data-cy="modal-submit-btn"]',
-    editRecord: (id) => `[data-cy="edit-btn-${id}"]`,
-    deleteRecord: (id) => `[data-cy="delete-btn-${id}"]`,
-    rowsPerPageSelect: '[data-cy="rows-per-page-select"]',
-    totalPages: '[data-cy="total-pages"]',
-    nextButton: '[data-cy="next-page-btn"]',
-    previousButton: '[data-cy="prev-page-btn"]',
+    modal: '[data-cy="registrationModal"]',
+    modalTitle: '[data-cy="modalTitle"]',
+    firstName: '[data-cy="modalFirstName"]',
+    lastName: '[data-cy="modalLastName"]',
+    email: '[data-cy="modalEmail"]',
+    age: '[data-cy="modalAge"]',
+    salary: '[data-cy="modalSalary"]',
+    department: '[data-cy="modalDepartment"]',
+    submitButton: '[data-cy="modalSubmitBtn"]',
+    editRecord: (id) => `[data-cy="editBtn${id}"]`,
+    deleteRecord: (id) => `[data-cy="deleteBtn${id}"]`,
+    rowsPerPageSelect: '[data-cy="rowsPerPageSelect"]',
+    totalPages: '[data-cy="totalPages"]',
+    nextButton: '[data-cy="nextPageBtn"]',
+    previousButton: '[data-cy="prevPageBtn"]',
   },
 
   /**
@@ -193,11 +193,11 @@ export const WebTablesPage = {
     cy.contains(this.selectors.rows, identifier).within(() => {
       cy.get(this.selectors.tableCell)
         .eq(6)
-        .find('[data-cy^="edit-btn-"]')
+        .find('[data-cy^="editBtn"]')
         .should("exist");
       cy.get(this.selectors.tableCell)
         .eq(6)
-        .find('[data-cy^="delete-btn-"]')
+        .find('[data-cy^="deleteBtn"]')
         .should("exist");
     });
     return this;

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,7 +25,7 @@ ajv.addSchema([
  * Wait for an element to be visible and then click it
  * Useful for elements that may take time to appear or need force clicking
  * @example
- * cy.waitAndClick('[data-cy="submit-btn"]')
+ * cy.waitAndClick('[data-cy="submitBtn"]')
  * cy.waitAndClick('.modal-button', { force: true, timeout: 15000 })
  * @param {string} selector - Element selector
  * @param {Object} [options={}] - Click options
@@ -46,7 +46,7 @@ Cypress.Commands.add("waitAndClick", (selector, options = {}) => {
 /**
  * Select a date from the custom datepicker component
  * @example
- * cy.selectDate('[data-cy="date-of-birth-input"]', 'January', '1990', '15')
+ * cy.selectDate('[data-cy="dateOfBirthInput"]', 'January', '1990', '15')
  * @param {string} dateInput - Selector for the date input
  * @param {string} month - Month name (e.g., 'January')
  * @param {string} year - Year (e.g., '1990')
@@ -54,9 +54,9 @@ Cypress.Commands.add("waitAndClick", (selector, options = {}) => {
  */
 Cypress.Commands.add("selectDate", (dateInput, month, year, day) => {
   cy.get(dateInput).click();
-  cy.get("[data-cy='month-select']").select(month);
-  cy.get("[data-cy='year-select']").select(year);
-  cy.get(`[data-cy="day-${day}"]`).first().click();
+  cy.get("[data-cy='monthSelect']").select(month);
+  cy.get("[data-cy='yearSelect']").select(year);
+  cy.get(`[data-cy="day${day}"]`).first().click();
 });
 
 // ============================================================
@@ -66,7 +66,7 @@ Cypress.Commands.add("selectDate", (dateInput, month, year, day) => {
 /**
  * Verify an element has a specific CSS property value
  * @example
- * cy.verifyCssProperty('[data-cy="first-name-input"]', 'border-color', 'rgb(220, 53, 69)')
+ * cy.verifyCssProperty('[data-cy="firstNameInput"]', 'border-color', 'rgb(220, 53, 69)')
  * @param {string} selector - Element selector
  * @param {string} property - CSS property name
  * @param {string} value - Expected CSS value
@@ -78,7 +78,7 @@ Cypress.Commands.add("verifyCssProperty", (selector, property, value) => {
 /**
  * Verify an input field has validation error styling
  * @example
- * cy.verifyValidationError('[data-cy="email-input"]')
+ * cy.verifyValidationError('[data-cy="emailInput"]')
  * @param {string} selector - Input selector
  * @param {string} [errorColor='rgb(220, 53, 69)'] - Expected error border color
  */


### PR DESCRIPTION
Follows adrianjiga.github.io#18, which converts every helper-page hook to camelCase in line with house style.

## Changes

62 selectors across the page objects and `commands.js`. Prefix matches lost their trailing hyphen — `[data-cy^="edit-btn-"]` → `[data-cy^="editBtn"]`.

**Country and city now take the visible name**, matching the generated hooks (`stateOptionGermany`, `cityOptionTheHague`):

```js
RegisterFormPage.selectState("Germany");   // was "germany"
RegisterFormPage.selectCity("Berlin");     // was "berlin"
```

Space-stripping lives in the selector builder, so `"The Hague"` resolves correctly without callers knowing the encoding.

## Verified

18/18 specs against a local server serving the updated pages (`--config baseUrl=…`). Lint, format, and typecheck clean.

## ⚠️ Merge order

Coordinated rename across four repositories. **The site must merge first**, then this and the sibling suites immediately after — the hooks are a contract with two sides, so any gap leaves one side querying values the other does not serve.

- adrianjiga.github.io#18 — the site (merge first)
- PlaywrightAutomationExample#40
- CypressAutomationExample#174
- SeleniumAutomationExample#60