### PR TITLE
test(a11y): add accessibility coverage with two-way baselines

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -42,6 +42,8 @@ jobs:
             tag: "@ui"
           - name: webtables
             tag: "@webTables"
+          - name: a11y
+            tag: "@a11y"
         browser: [chrome, firefox]
         viewport: [desktop]
         exclude:
@@ -51,6 +53,11 @@ jobs:
           - group:
               name: api
             viewport: mobile
+          # The accessibility audit reads the DOM, not the rendering, so a second engine
+          # re-runs identical logic against an identical tree and adds no signal.
+          - group:
+              name: a11y
+            browser: firefox
 
     steps:
       - name: Checkout Repository

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A production-ready Cypress testing framework demonstrating UI, API, and table in
 - **Multi-Browser Testing** - Chrome, Firefox, and Edge support
 - **Responsive Testing** - Mobile, tablet, and desktop viewport configurations
 - **API Testing** - RESTful API validation with schema verification
+- **Accessibility Testing** - Per-page audits with two-way baselines, powered by WebQualityAnalyzer
 - **Docker Support** - Containerized test execution
 - **CI/CD Ready** - GitHub Actions workflows for automated testing
 - **Mochawesome Reports** - HTML test reports with screenshots and videos
@@ -33,6 +34,7 @@ npm install
 ```
 ├── cypress/
 │   ├── e2e/                          # Test specifications
+│   │   ├── accessibility.cy.js       # Per-page accessibility baselines
 │   │   ├── api.cy.js                 # JSONPlaceholder API tests
 │   │   ├── buttons.cy.js             # Button interaction tests
 │   │   ├── registerForm.cy.js        # Form validation tests
@@ -52,6 +54,7 @@ npm install
 │   │   ├── WebTablesPage.js
 │   │   └── index.js
 │   └── support/
+│       ├── accessibility.js          # Analyzer injection + two-way baseline assertion
 │       ├── commands.js               # Custom Cypress commands
 │       ├── e2e.js                    # Global configuration
 │       ├── factories.js              # Test data factories
@@ -93,6 +96,7 @@ npm run test:ui           # UI tests (@ui)
 npm run test:api          # API tests (@api)
 npm run test:webtables    # Table tests (@webTables)
 npm run test:smoke        # Smoke tests (@smoke)
+npm run test:a11y         # Accessibility tests (@a11y)
 ```
 
 ### Browser Selection
@@ -161,6 +165,28 @@ JSON path — not just the first one it hits.
 |-----------|----------|
 | `webTables.cy.js` | Search, edit, add, delete records, pagination, rows per page |
 
+### Accessibility Tests (`@a11y`)
+
+| Test File | Coverage |
+|-----------|----------|
+| `accessibility.cy.js` | Buttons, Web Tables, Register Form, and the Register Form's submitted state |
+
+Auditing is powered by [WebQualityAnalyzer](https://github.com/adrianjiga/WebQualityAnalyzer)
+— the same engine that drives its browser extension, published as a browser bundle for exactly
+this use. `cy.auditAccessibility()` injects it into the page under test and yields the
+accessibility findings; SEO and performance analysis are disabled, because they audit the
+*page* rather than the behaviour under test.
+
+**The baseline is two-way, and the second direction is the point.** A new issue fails, and a
+baseline entry that *stops occurring* also fails. Without the second check a baseline is just
+a suppression list: it only ever grows, and nothing tells you an entry went stale. With it,
+fixing a page forces the baseline to shrink. All four baselines are currently empty, so these
+pages are held at zero.
+
+The submitted-state test exists because auditing only the initial render misses whatever a
+page reveals at runtime — the confirmation modal is hidden until submit, and a heading-
+hierarchy defect once lived there.
+
 ## Page Objects
 
 The framework uses Page Object Model for maintainable test code:
@@ -216,6 +242,11 @@ Defined in `cypress/support/commands.js`, typed in `cypress/support/index.d.ts`.
 ### Assertions
 - `cy.verifyCssProperty(selector, property, value)` - CSS validation
 - `cy.verifyValidationError(selector, errorColor?)` - Form error styling
+
+### Accessibility
+- `cy.auditAccessibility()` - Inject WebQualityAnalyzer and yield the page's accessibility findings.
+  Registered in `cypress/support/accessibility.js`, which also exports
+  `expectAccessibilityBaseline(issues, baseline)`
 
 ### API Helpers
 - `cy.apiRequest(method, url, options)` - Request with default headers, `failOnStatusCode: false`
@@ -274,7 +305,7 @@ Three jobs:
 
 | Job | Shape |
 |-----|-------|
-| `test` | Groups (`@api`, `@ui`, `@webTables`) × Browsers (Chrome, Firefox) at the desktop viewport. `@api` is skipped on Firefox — the suite makes no browser-specific assertions, so a second engine buys nothing. |
+| `test` | Groups (`@api`, `@ui`, `@webTables`, `@a11y`) × Browsers (Chrome, Firefox) at the desktop viewport. `@api` is skipped on Firefox — the suite makes no browser-specific assertions, so a second engine buys nothing. `@a11y` is skipped for the same reason: the audit reads the DOM, not the rendering. |
 | `responsive-tests` | `@ui` only, on Chrome, at the mobile and tablet viewports. Separate from the main matrix so viewport coverage doesn't multiply against the browser axis. |
 | `merge-reports` | Runs after both (`if: always()`), downloads every shard's artifacts and merges the mochawesome JSON into a single HTML report. |
 

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -2,12 +2,26 @@
 import { defineConfig } from "cypress";
 import { plugin } from "@cypress/grep/plugin";
 import fs from "fs";
+import { createRequire } from "node:module";
 
 const viewports = {
   mobile: { width: 375, height: 667 },
   tablet: { width: 768, height: 1024 },
   desktop: { width: 1920, height: 1080 },
 };
+
+/**
+ * Absolute path to the WebQualityAnalyzer browser bundle, resolved here in Node because a
+ * spec runs in the browser and has no module resolution of its own. Letting npm decide where
+ * the package lives means a hoisted or nested install both work — hardcoding
+ * `node_modules/webqualityanalyzer/...` would break the moment the tree changes shape.
+ *
+ * `require.resolve` does not exist in an ES module and this project is `"type": "module"`,
+ * hence `createRequire`.
+ */
+const wqaBundlePath = createRequire(import.meta.url).resolve(
+  "webqualityanalyzer/wqa.js"
+);
 
 export default defineConfig({
   allowCypressEnv: false,
@@ -32,6 +46,7 @@ export default defineConfig({
     grepFilterSpecs: true,
     grepOmitFiltered: true,
     viewports: viewports,
+    wqaBundlePath,
   },
   e2e: {
     baseUrl: "https://adrianjiga.github.io",

--- a/cypress/e2e/accessibility.cy.js
+++ b/cypress/e2e/accessibility.cy.js
@@ -1,0 +1,100 @@
+import { ButtonsPage, RegisterFormPage, WebTablesPage } from "../pages";
+import { expectAccessibilityBaseline } from "../support/accessibility";
+
+/**
+ * Accessibility coverage for the helper pages, using the analyzer from the
+ * WebQualityAnalyzer project (the same engine behind its browser extension).
+ *
+ * ## Why these tests have a baseline instead of asserting zero
+ *
+ * The helper pages have real, pre-existing accessibility defects. Asserting zero today would
+ * make the suite red on arrival, which teaches everyone to ignore it. Instead each page
+ * declares exactly what is currently wrong, and the assertion is two-way: a **new** issue
+ * fails, and a baseline entry that stops occurring **also** fails so it must be deleted.
+ *
+ * The baseline is therefore a shrinking record of known debt, not a suppression list.
+ *
+ * ## Scope
+ *
+ * Accessibility only. SEO and performance are disabled in `cy.auditAccessibility()` — they
+ * audit page quality, not the behaviour under test.
+ */
+
+/**
+ * Known, accepted issues per page. Format: `type @ selector — message`.
+ *
+ * **All three pages are currently at zero**, and the analyzer is DOM-based, so these match
+ * the Playwright suite's baselines exactly. If the two ever disagree, the difference is real
+ * and worth understanding rather than papering over — the pages are the same pages.
+ *
+ * Adding an entry here is a deliberate act. Do it only with a comment saying why the issue is
+ * acceptable, and treat it as debt to remove rather than a permanent exception.
+ */
+const BASELINE = {
+  buttons: [],
+  webTables: [],
+  registerForm: [],
+};
+
+describe("Accessibility", () => {
+  it("buttons page has no accessibility issues", { tags: ["@a11y"] }, () => {
+    ButtonsPage.visit();
+
+    cy.auditAccessibility().then(({ issues, score }) => {
+      expectAccessibilityBaseline(issues, BASELINE.buttons);
+      expect(score).to.equal(100);
+    });
+  });
+
+  it(
+    "web tables page matches its accessibility baseline",
+    { tags: ["@a11y"] },
+    () => {
+      WebTablesPage.visit();
+
+      cy.auditAccessibility().then(({ issues }) => {
+        expectAccessibilityBaseline(issues, BASELINE.webTables);
+      });
+    }
+  );
+
+  it(
+    "register form matches its accessibility baseline",
+    { tags: ["@a11y"] },
+    () => {
+      RegisterFormPage.visit();
+
+      cy.auditAccessibility().then(({ issues }) => {
+        expectAccessibilityBaseline(issues, BASELINE.registerForm);
+      });
+    }
+  );
+
+  it(
+    "submitted-state register form reports no new issues",
+    { tags: ["@a11y"] },
+    () => {
+      // Auditing only the initial render misses whatever a page reveals at runtime — the
+      // confirmation modal is hidden until submit, and it is where the heading-hierarchy
+      // defect used to live.
+      //
+      // Date of birth is required for submission alongside first name, last name, mobile and
+      // gender, and it cannot be typed — it must be picked. Omitting it leaves the form
+      // blocked by validation and the modal shut.
+      RegisterFormPage.visit();
+      RegisterFormPage.fillCompleteForm({
+        firstName: "Ada",
+        lastName: "Lovelace",
+        mobile: "1234567890",
+        gender: "male",
+        dateOfBirth: { month: "January", year: "1990", day: "01" },
+      });
+      RegisterFormPage.submit();
+      RegisterFormPage.verifySubmissionSuccess();
+
+      cy.auditAccessibility().then(({ issues }) => {
+        expectAccessibilityBaseline(issues, BASELINE.registerForm);
+      });
+    }
+  );
+});

--- a/cypress/support/accessibility.js
+++ b/cypress/support/accessibility.js
@@ -1,0 +1,142 @@
+/**
+ * Accessibility auditing built on the WebQualityAnalyzer project — the same engine that
+ * drives its browser extension, published as a plain browser bundle for exactly this use.
+ *
+ * @see https://github.com/adrianjiga/WebQualityAnalyzer
+ */
+
+/**
+ * @typedef {Object} A11yIssue
+ * @property {string} type - e.g. "Form Accessibility"
+ * @property {string} message
+ * @property {'high'|'medium'|'low'} severity
+ * @property {string} [selector] - CSS path to the first offending element
+ * @property {string} [htmlSnippet]
+ */
+
+/**
+ * The bundle source, read once per spec run rather than once per audit. `cy.readFile` hits
+ * the Node process on every call, and the file is the same on all of them.
+ * @type {string | undefined}
+ */
+let bundleSource;
+
+/**
+ * The bundle assigns its global at runtime, which static analysis cannot see. The cast
+ * borrows the package's own emitted declarations rather than reaching for `any`, so the shape
+ * of the analysis result stays checked.
+ *
+ * @param {Cypress.AUTWindow} win
+ * @returns {typeof import("webqualityanalyzer") | undefined}
+ */
+function analyzerIn(win) {
+  return /** @type {Cypress.AUTWindow & { WebQualityAnalyzer?: typeof import("webqualityanalyzer") }} */ (
+    win
+  ).WebQualityAnalyzer;
+}
+
+/**
+ * Injects the analyzer bundle into the application window.
+ *
+ * It must be evaluated in the window's **global** scope: the bundle is an IIFE whose first
+ * statement is `var WebQualityAnalyzer`, so anywhere else that assignment stays local and the
+ * global never appears. A `<script>` element is the unambiguous way to get global scope —
+ * `cy.window().then(win => win.eval(src))` also works, because a method call on `win` is an
+ * *indirect* eval, but that is a subtlety a reader has to know rather than see.
+ *
+ * @param {Cypress.AUTWindow} win
+ */
+function injectAnalyzer(win) {
+  if (analyzerIn(win)) {
+    return;
+  }
+  const script = win.document.createElement("script");
+  script.textContent = bundleSource;
+  win.document.head.appendChild(script);
+}
+
+/**
+ * Runs the analyzer against the page currently under test and yields its accessibility
+ * findings.
+ *
+ * SEO and performance are switched off deliberately. They audit the *page*, not the
+ * behaviour under test, and their findings (a missing meta description, an unminified
+ * script) are not defects of a QA helper fixture — including them would make this suite fail
+ * over things it has no opinion about.
+ *
+ * `analyzePage` is synchronous, so the result is available in the same tick as the call.
+ *
+ * @example
+ * cy.auditAccessibility().then(({ issues }) => {
+ *   expectAccessibilityBaseline(issues, []);
+ * });
+ */
+Cypress.Commands.add("auditAccessibility", () => {
+  const withSource = bundleSource
+    ? cy.wrap(bundleSource, { log: false })
+    : cy
+        .readFile(Cypress.expose("wqaBundlePath"), { log: false })
+        .then((src) => {
+          bundleSource = src;
+          return src;
+        });
+
+  return withSource.then(() =>
+    cy.window({ log: false }).then((win) => {
+      injectAnalyzer(win);
+      return analyzerIn(win).analyzePage({
+        seo: { enabled: false },
+        performance: { enabled: false },
+      }).categories.accessibility;
+    })
+  );
+});
+
+/**
+ * Full-fidelity identity for an issue: any change to type, location, or message is a change.
+ *
+ * Deliberately the same format as the Playwright suite's, so a finding can be compared across
+ * repositories by eye without translating between two notations.
+ *
+ * @param {A11yIssue} issue
+ * @returns {string}
+ */
+function fingerprint(issue) {
+  return `${issue.type} @ ${issue.selector ?? "(page)"} — ${issue.message}`;
+}
+
+/**
+ * Asserts the page's accessibility findings match `baseline` exactly.
+ *
+ * This is a two-way check, and the second direction is the important one:
+ *
+ * 1. An issue **not** in the baseline fails — a new accessibility regression.
+ * 2. A baseline entry that **no longer occurs** also fails — the debt was paid, so the
+ *    entry must go.
+ *
+ * Without (2) a baseline is just a suppression list: it only ever grows, and nothing ever
+ * tells you an entry became obsolete. With it, fixing the page *forces* the baseline to
+ * shrink, so the file stays an accurate record of known debt rather than a graveyard.
+ *
+ * A page with no known issues passes `[]` and is held at zero from then on.
+ *
+ * @param {A11yIssue[]} issues - what the analyzer found
+ * @param {string[]} baseline - fingerprints of accepted, documented issues
+ */
+export function expectAccessibilityBaseline(issues, baseline) {
+  const found = issues.map(fingerprint);
+
+  const regressions = found.filter((f) => !baseline.includes(f));
+  expect(
+    regressions,
+    "New accessibility issue(s) not in the baseline. Fix the page, or — if this is genuinely " +
+      "acceptable — add the exact string(s) to the baseline with a comment explaining why"
+  ).to.deep.equal([]);
+
+  const resolved = baseline.filter((b) => !found.includes(b));
+  expect(
+    resolved,
+    "Baseline entr(ies) no longer reported — the page was fixed. Remove them so the baseline " +
+      "keeps reflecting reality"
+  ).to.deep.equal([]);
+}

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,4 +1,5 @@
 import "./commands";
+import "./accessibility";
 import "cypress-wait-until";
 import { register } from "@cypress/grep";
 

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -51,7 +51,24 @@ declare namespace Cypress {
      * @param selector - Input selector
      * @param errorColor - Expected error border color (default: 'rgb(220, 53, 69)')
      */
-    verifyValidationError(selector: string, errorColor?: string): Chainable<void>;
+    verifyValidationError(
+      selector: string,
+      errorColor?: string
+    ): Chainable<void>;
+
+    // ============================================================
+    // ACCESSIBILITY COMMANDS
+    // ============================================================
+
+    /**
+     * Inject the WebQualityAnalyzer bundle into the page under test and yield its
+     * accessibility findings. SEO and performance analysis are disabled.
+     *
+     * Pair with `expectAccessibilityBaseline` from `cypress/support/accessibility`.
+     */
+    auditAccessibility(): Chainable<
+      import("webqualityanalyzer").CategoryResult
+    >;
 
     // ============================================================
     // API HELPER COMMANDS
@@ -89,7 +106,10 @@ declare namespace Cypress {
      * @param message - Message to log
      * @param data - Optional data to include
      */
-    logMessage(message: string, data?: Record<string, unknown>): Chainable<void>;
+    logMessage(
+      message: string,
+      data?: Record<string, unknown>
+    ): Chainable<void>;
 
     /**
      * Take a screenshot with a descriptive name
@@ -122,6 +142,5 @@ declare namespace Cypress {
         log?: boolean;
       }
     ): Chainable<boolean>;
-
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "mochawesome-merge": "^5.1.1",
         "mochawesome-report-generator": "^6.3.2",
         "prettier": "^3.9.6",
-        "typescript": "^7.0.2"
+        "typescript": "^7.0.2",
+        "webqualityanalyzer": "github:adrianjiga/WebQualityAnalyzer"
       },
       "engines": {
         "node": ">=20.0.0",
@@ -5035,6 +5036,11 @@
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
       }
+    },
+    "node_modules/webqualityanalyzer": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/adrianjiga/WebQualityAnalyzer.git#7e8262854ce6fc16e27385c19d6f626266ab150e",
+      "dev": true
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "report:full": "npm run report:merge && npm run report:generate",
     "clean": "rm -rf reports cypress/videos cypress/screenshots node_modules/.cache",
     "clean:reports": "rm -rf reports",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:a11y": "cypress run --expose grepTags=@a11y"
   },
   "repository": {
     "type": "git",
@@ -81,6 +82,7 @@
     "mochawesome-merge": "^5.1.1",
     "mochawesome-report-generator": "^6.3.2",
     "prettier": "^3.9.6",
-    "typescript": "^7.0.2"
+    "typescript": "^7.0.2",
+    "webqualityanalyzer": "github:adrianjiga/WebQualityAnalyzer"
   }
 }


### PR DESCRIPTION
Ports the accessibility pattern already running in the Playwright suite over to Cypress, using the same analyzer so findings are comparable across repos.

## What's here

- **`cy.auditAccessibility()`** (`cypress/support/accessibility.js`) — injects the [WebQualityAnalyzer](https://github.com/adrianjiga/WebQualityAnalyzer) browser bundle into the page under test and yields its accessibility findings. SEO and performance are disabled: they audit the *page*, not the behaviour under test.
- **`expectAccessibilityBaseline(issues, baseline)`** — two-way check. A new issue fails, *and* a baseline entry that no longer occurs fails. Without the second direction a baseline is just a suppression list that only ever grows.
- **`cypress/e2e/accessibility.cy.js`** — four `@a11y` specs: Buttons, Web Tables, Register Form, and the Register Form's **submitted state**. All baselines are empty, so these pages are held at zero.
- **`@a11y` shard** in the scheduled matrix, Chrome only.

## Two implementation notes

**The bundle must be evaluated in global scope.** Its first statement is `var WebQualityAnalyzer`, which only becomes a window property at global scope. A `<script>` element makes that unambiguous — `win.eval(src)` also works (a method call on `win` is an *indirect* eval) but relies on a subtlety a reader has to already know.

**The bundle path is resolved in Node, not the browser.** `cypress.config.js` resolves it via `createRequire` and hands it to the spec through `expose`, so npm decides where the package lives; hardcoding `node_modules/...` would break under a different tree shape.

## Verification

4/4 passing against the live site. Because an empty baseline can pass vacuously, I also confirmed the audit is live: injecting an `<img>` with no `alt` into the Buttons page produces a finding. The zeros are real.

`npm run lint`, `npm run format:check`, and `npm run typecheck` all clean.