### PR TITLE
docs(pages): correct the stale city hook rule in selectCity

### DIFF
--- a/cypress/pages/RegisterFormPage.js
+++ b/cypress/pages/RegisterFormPage.js
@@ -157,8 +157,9 @@ export const RegisterFormPage = {
    * Select a city from the custom dropdown. Cities are populated by the chosen country, so
    * this must run after {@link selectState}.
    *
-   * Lower-cased and hyphenated, matching how the page builds the attribute, so "Frankfurt"
-   * is `frankfurt`.
+   * The hook is the visible name with spaces removed and capitalisation preserved, matching
+   * how the page builds the attribute, so "Frankfurt" is `cityOptionFrankfurt` and "The
+   * Hague" is `cityOptionTheHague`.
    *
    * @param {string} city - the visible name, e.g. "Berlin"
    */


### PR DESCRIPTION
Companion to PlaywrightAutomationExample#43 — the same wrong rule was duplicated in both page objects.

`selectCity()`'s docstring claimed the city hook is "lower-cased and hyphenated ... so 'Frankfurt' is `frankfurt`". The selector two lines below does the opposite:

```js
cityOption: (city) => `[data-cy="cityOption${city.replace(/\s+/g, "")}"]`
```

Spaces are removed and capitalisation is **preserved** — lower-casing would flatten the camel humps. "The Hague" is `cityOptionTheHague`.

The docstring was correct before the camelCase migration and was never updated with the code. Anyone adding a city by following it would have produced a selector matching nothing.

`npm run lint` and `npm run format:check` clean.