### PR TITLE
docs(readme): link the cross-repo architecture notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A production-ready Cypress testing framework demonstrating UI, API, and table interaction testing patterns against self-hosted helper pages at [adrianjiga.github.io/qa/helpers](https://adrianjiga.github.io/qa/helpers). Features Page Object Model architecture, test data factories, multi-browser support, responsive testing, and CI/CD integration.
 
+> **Architecture** — this repository is one of six that behave as a single system.
+> The [cross-repo architecture notes](https://adrianjiga.github.io/qa/architecture)
+> cover the `data-cy` contract, the coordinated-deploy problem, and the known gaps.
+
 ## Features
 
 - **Page Object Model** - Clean separation of test logic and page interactions


### PR DESCRIPTION
Points at the new [architecture page](https://adrianjiga.github.io/qa/architecture) (adrianjiga.github.io#21) rather than restating any of it here.

The page covers the `data-cy` contract these suites depend on, why a two-sided contract across repositories cannot be changed atomically, and the known gaps. Keeping it in one place is the same rule the rest of this portfolio now enforces: a fact that lives in two places diverges.

Merge after adrianjiga.github.io#21, or the link 404s until Pages deploys.